### PR TITLE
Update gravityformsImporter.php

### DIFF
--- a/gravityformsImporter.php
+++ b/gravityformsImporter.php
@@ -84,16 +84,14 @@ foreach($response->response->entries as $entry) {
 			$field_values[$key] = $value;
 		}
 	}
-	$content = "
-	{{" . $settings['template_name'] . "
-	|" . 
-	implode("|\n", array_map(
+	$content = "{{" . $settings['template_name'] . "\n	|" . 
+	implode("\n	|", array_map(
 		function ($v, $k) { return $k . '=' . $v; },
 		$field_values,
 		array_keys( $field_values )
 		)
 	) . 
-	"}}";
+	"\n}}";
 	if ( !empty( $settings['destNamespace'] ) ) {
 		$pageName = $settings['destNamespace'] . ':' . $pageName;
 	}


### PR DESCRIPTION
These few edits would improve the rendering of the template text on the wiki page side of things. From: 
```
	{{SubmittedReport
	|date_created=2018-12-21 17:29:22|
1=First Last|
7=email@hotmail.com|
2=Some value|
4=2018|
5=|
6=Some_file.pdf}}
```
to 
```
{{SubmittedReport
	|date_created=2018-12-21 17:29:22
	|1=First Last
	|7=email@hotmail.com
	|2=Some value
	|4=2018
	|5=
	|6=Some_file.pdf
}}
```